### PR TITLE
Add CORS header

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -18,6 +18,7 @@ module DeliveryMechanism
       create_chirp_file unless chirp_file_exists?
 
       content_type 'application/json'
+      headers "Access-Control-Allow-Origin" => '*'
     end
 
     get '/timeline' do


### PR DESCRIPTION
Allows devs to use it whilst developing JS based API interfaces locally.